### PR TITLE
Refactoring, TUI options from desktop and shell, GTK name for better display on some system

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -12,7 +12,7 @@ pkgbase = neovim-gnome-terminal-wrapper
 	source = nvim-wrapper
 	source = neovim.svg
 	md5sums = c5b9b5db24db814376b6925ce0f9ad52
-	md5sums = c519ffa40ad62448f51bdd91e32518e0
+	md5sums = 31d6960e3dd9592a812cba50ca895c4f
 	md5sums = 2b271742492f200bcac78dbfe33caa3c
 
 pkgname = neovim-gnome-terminal-wrapper

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = neovim-gnome-terminal-wrapper
 	pkgdesc = A wrapper for running neovim in a separate instance of gnome-terminal
-	pkgver = 1
-	pkgrel = 6
+	pkgver = 2
+	pkgrel = 1
 	url = http://github.com/fmoralesc/
 	arch = any
 	license = GPL
@@ -11,8 +11,8 @@ pkgbase = neovim-gnome-terminal-wrapper
 	source = neovim.desktop
 	source = nvim-wrapper
 	source = neovim.svg
-	md5sums = fe784928af34009c09c7fcdd4e731fe4
-	md5sums = 02f2a478f4a11ba591b75e2cf6aee31a
+	md5sums = c5b9b5db24db814376b6925ce0f9ad52
+	md5sums = c519ffa40ad62448f51bdd91e32518e0
 	md5sums = 2b271742492f200bcac78dbfe33caa3c
 
 pkgname = neovim-gnome-terminal-wrapper

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,7 @@ source=('neovim.desktop'
         'nvim-wrapper'
         'neovim.svg')
 md5sums=('c5b9b5db24db814376b6925ce0f9ad52'
-         'c519ffa40ad62448f51bdd91e32518e0'
+         '31d6960e3dd9592a812cba50ca895c4f'
          '2b271742492f200bcac78dbfe33caa3c')
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,16 +1,19 @@
 # Maintainer: Felipe Morales <hel.sheep@gmail.com>
 pkgname=neovim-gnome-terminal-wrapper
-pkgver=1
-pkgrel=6
+pkgver=2
+pkgrel=1
 pkgdesc="A wrapper for running neovim in a separate instance of gnome-terminal"
 arch=(any)
 url="http://github.com/fmoralesc/"
 license=('GPL')
 groups=()
 depends=('python-dbus' 'neovim-git' 'gnome-terminal') 
-source=(neovim.desktop nvim-wrapper neovim.svg)
-md5sums=('fe784928af34009c09c7fcdd4e731fe4' '02f2a478f4a11ba591b75e2cf6aee31a' '2b271742492f200bcac78dbfe33caa3c')
-
+source=('neovim.desktop'
+        'nvim-wrapper'
+        'neovim.svg')
+md5sums=('c5b9b5db24db814376b6925ce0f9ad52'
+         'c519ffa40ad62448f51bdd91e32518e0'
+         '2b271742492f200bcac78dbfe33caa3c')
 
 package() {
   cd "$srcdir/"

--- a/neovim.desktop
+++ b/neovim.desktop
@@ -3,7 +3,7 @@ Version=1.0
 Type=Application
 Name=Neovim
 Icon=neovim
-Exec=env NVIM_TUI_ENABLE_TRUE_COLOR=1 nvim-wrapper %F
+Exec=nvim-wrapper %F
 NoDisplay=false
 Categories=X-GNOME-Other;
 StartupNotify=false

--- a/nvim-wrapper
+++ b/nvim-wrapper
@@ -1,19 +1,49 @@
 #!/usr/bin/env python3
 
-from sys import argv
-from subprocess import Popen
-from time import time
+"""Run nvim inside gnome-terminal"""
+
+import sys
+import os
+import subprocess
 import dbus
+from time import time
 
-session_bus = dbus.SessionBus()
+SERVER_CMD = [
+    '/usr/lib/gnome-terminal/gnome-terminal-server',
+    '--app-id=org.neovim',
+]
+TERM_CMD = [
+    'gnome-terminal',
+    '--name=Neovim',
+    '--hide-menubar',
+    '--geometry=90x60',
+    '--app-id=org.neovim',
+    '--class=neovim',
+    '-x',
+    'nvim'
+]
 
-# launch the terminal server with a custom app-id and window class (so the .desktop file gets associated)
-if not session_bus.name_has_owner('org.neovim'):
-    Popen("/usr/lib/gnome-terminal/gnome-terminal-server --app-id org.neovim --class=neovim".split())
-# wait until the name is registered, or 2 seconds pass (when launching from cold cache it might more time)
-timeout = time() + 2
-while not session_bus.name_has_owner('org.neovim') and time() <= timeout:
-    pass
-# launch nvim in a gnome-terminal instance
-if session_bus.name_has_owner('org.neovim'):
-    Popen("gnome-terminal --app-id org.neovim -x nvim".split() + argv[1:])
+def main():
+    """Run nvim inside gnome-terminal"""
+    session_bus = dbus.SessionBus()
+
+    # launch the terminal server with a custom app-id
+    # and window class (so the .desktop file gets associated)
+    if not session_bus.name_has_owner('org.neovim'):
+        subprocess.Popen(SERVER_CMD)
+
+    # wait until the name is registered, or 2 seconds pass (when launching from
+    # cold cache it might more time)
+    timeout = time() + 2
+    while not session_bus.name_has_owner('org.neovim') and time() <= timeout:
+        pass
+    # launch nvim in a gnome-terminal instance
+    if session_bus.name_has_owner('org.neovim'):
+        with open(os.devnull, 'wb') as fnull:
+            subprocess.Popen(TERM_CMD + sys.argv[1:],
+                             stdout=fnull,
+                             stderr=fnull)
+                             # preexec_fn=os.setpgrp)
+
+if __name__ == '__main__':
+    main()

--- a/nvim-wrapper
+++ b/nvim-wrapper
@@ -8,19 +8,26 @@ import subprocess
 import dbus
 from time import time
 
+
+APP_ID = 'org.neovim'
+CLASS = 'neovim'
+NAME = 'Neovim'
+
 SERVER_CMD = [
     '/usr/lib/gnome-terminal/gnome-terminal-server',
-    '--app-id=org.neovim',
+    '--app-id', APP_ID,
+    '--class', CLASS,
+    '--name', NAME,
 ]
 TERM_CMD = [
     'gnome-terminal',
-    '--name=Neovim',
+    '--app-id', APP_ID,
+    '--class', CLASS,
+    '--name', NAME,
     '--hide-menubar',
-    '--geometry=90x60',
-    '--app-id=org.neovim',
-    '--class=neovim',
+    '--geometry', '90x60',
     '-x',
-    'nvim'
+    'nvim',
 ]
 
 def main():
@@ -29,21 +36,24 @@ def main():
 
     # launch the terminal server with a custom app-id
     # and window class (so the .desktop file gets associated)
-    if not session_bus.name_has_owner('org.neovim'):
+    if not session_bus.name_has_owner(APP_ID):
         subprocess.Popen(SERVER_CMD)
 
     # wait until the name is registered, or 2 seconds pass (when launching from
     # cold cache it might more time)
     timeout = time() + 2
-    while not session_bus.name_has_owner('org.neovim') and time() <= timeout:
+    while not session_bus.name_has_owner(APP_ID) and time() <= timeout:
         pass
     # launch nvim in a gnome-terminal instance
-    if session_bus.name_has_owner('org.neovim'):
+    if session_bus.name_has_owner(APP_ID):
+        env = os.environ.copy()
+        env['NVIM_TUI_ENABLE_CURSOR_SHAPE'] = '1'
+        env['NVIM_TUI_ENABLE_TRUE_COLOR'] = '1'
         with open(os.devnull, 'wb') as fnull:
             subprocess.Popen(TERM_CMD + sys.argv[1:],
                              stdout=fnull,
-                             stderr=fnull)
-                             # preexec_fn=os.setpgrp)
+                             stderr=fnull,
+                             env=env)
 
 if __name__ == '__main__':
     main()

--- a/nvim-wrapper
+++ b/nvim-wrapper
@@ -25,7 +25,6 @@ TERM_CMD = [
     '--class', CLASS,
     '--name', NAME,
     '--hide-menubar',
-    '--geometry', '90x60',
     '-x',
     'nvim',
 ]


### PR DESCRIPTION
Hi fmoralesc

First thanks ! what a great idea to package this.

Then, I noticed some minor issues when using your script on my setup. First, I had inconsistencies between running nvim-wrapper trough the desktop link or directly with nvim-wraper (notably for TUI colors). Second, my Gnome Classic still displayed Terminal in the top bar.

So, I forked it. I addressed the first issue by adding environment variables in the script (I also added the one for cursor). For the second, I added the GTK `--name` parameter to the command line. Otherwise, I did some refactoring. My version also sends stdout and stderr to /dev/null and sets a default size for the window.

Because every thing seems a lot better to me, I feel like share it. Yet it's very subjective, so feel free to pick and choose what you want from it.

Thanks again.
