### PR TITLE
nvim-wapper: Add option -f to wait for completion

### DIFF
--- a/nvim-wrapper
+++ b/nvim-wrapper
@@ -57,6 +57,8 @@ def processArgv():
         argParts = arg.split('=', 1)
         if argParts[0] in GTERM_PASSTHROUGH_OPTIONS:
             gtermOptions.append(arg)
+        elif arg=='-f':
+            gtermOptions.append('--wait')
         else:
             nvimOptions.append(arg)
 
@@ -94,9 +96,11 @@ def main():
         options = processArgv()
         cmd = [] + TERM_CMD[:-2] + options['gterm'] + TERM_CMD[-2:] + options['nvim']
         with open(os.devnull, 'wb') as fnull:
-            subprocess.Popen(cmd,
+            p=subprocess.Popen(cmd,
                              stdout=fnull,
                              stderr=fnull)
+        if '--wait' in options['gterm']:
+            p.wait()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
One last remaining showstopper for using nvim-wrapper as a gvim replacement is to make the editor command wait for completion, for example to input a comment when checking in a revision. I used EDITOR="gvim -f" for that. Attached is my modification for nvim-wrapper to accept the -f flag as well, and then wait for completion.